### PR TITLE
fix(help-find): avoid cloning meta when preparing join query

### DIFF
--- a/lib/waterline/utils/query/help-find.js
+++ b/lib/waterline/utils/query/help-find.js
@@ -354,7 +354,8 @@ module.exports = function helpFind(WLModel, s2q, omen, done) {
               // collecting the results in a dictionary organized by parent PK.
               async.reduce(parentPks, {}, function(memo, parentPk, nextParentPk) {
 
-                var childTableQuery = _.cloneDeep(baseChildTableQuery);
+                var childTableQuery = _.cloneDeep(_.omit(baseChildTableQuery, 'meta'));
+                childTableQuery.meta = baseChildTableQuery.meta;
 
                 // Get all the records in the junction table result where the value of the foreign key
                 // to the parent table is equal to the parent table primary key value we're currently looking at.
@@ -526,7 +527,8 @@ module.exports = function helpFind(WLModel, s2q, omen, done) {
               }
 
               // Start with a copy of the base query.
-              var childTableQuery = _.cloneDeep(baseChildTableQuery);
+              var childTableQuery = _.cloneDeep(_.omit(baseChildTableQuery, 'meta'));
+              childTableQuery.meta = baseChildTableQuery.meta;
 
               // Create a conjunct that will look for child records whose join key value matches
               // this parent record's PK value, then push that on to our `and` predicate.


### PR DESCRIPTION
Applying the base query’s `meta` object by reference here should resolve an issue where prototype information of our `meta.leasedConnection` object is lost due to the deep clone.

When the leased connection object loses its original prototype, we’re liable to see breakage in adapters due to expected properties no longer being present. For example, [sails-mongo](https://github.com/balderdashy/sails-mongo) requires an accessible `collection` property, though this will be lost in our clone and thus yield an error when an attempt is made to call it as a function.

For the purpose of performance (perhaps a micro-optimisation for some), this commit has our `meta` object shared between the parent and child queries. This appears to be safe in my testing with sails-mongo, but could cause issues if an adapter decided to modify the `meta` object.